### PR TITLE
Update README.md to mention python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ These instructions will get you a copy of the script up and running on your loca
 
 ### Prerequisites
 
-1. **Install [Python 3.7 or greater](https://www.python.org/downloads/)**.
+1. **Install [Python 3.7 - 3.9 or greater](https://www.python.org/downloads/)**.
 2. **Install [Git](https://git-scm.com/downloads)**.
 
 ### Installation and execution


### PR DESCRIPTION
### What is the problem?
Iterable was removed from collections in `3.10`:

https://docs.python.org/3/whatsnew/3.10.html#removed

The underlying canvasapi relies on Iterable being imported from collections so you cannot use a version higher than `3.9`